### PR TITLE
Compatibility to new CUDA versions

### DIFF
--- a/PFAC/common.mk
+++ b/PFAC/common.mk
@@ -42,27 +42,7 @@ LINK := $(if $(filter $(machine),x86_64),g++ -m64 -fopenmp -Wall,g++ -m32 -fopen
 
 NVCC := $(if $(filter $(machine),x86_64),nvcc -m64,nvcc -m32)
 
-#
-# CUDA 3.0 cannot compile sm_21, it reports
-#   nvcc fatal?? : Value 'sm_21' is not defined for option 'gpu-architecture'
-# 
-# variable 'cuda_32' is used to detect if sm21 can be compiled or not
-# it is used in src/Makefile
-# 
-# CUDA 4.0
-#   Cuda compilation tools, release 4.0, V0.2.1221  
-#
-#cuda_32 := $(if $(shell nvcc -V | grep 3.2),1,)
-#cuda_40 := $(if $(shell nvcc -V | grep 4.0),1,)
-#sm_21_support := $(if $(filter 1, $(cuda_32) $(cuda_40)),1,)
-
-words := $(shell nvcc -V | grep tools)
-nvcc_v_comma := $(filter-out Cuda compilation tools% release V%, $(words))
-comma := ,
-nvcc_version := $(subst $(comma),,$(nvcc_v_comma))
-sm_21_support := $(if $(filter $(nvcc_version), 3.2 4.0 4.1 4.2),1,)
-sm_30_support := $(if $(filter $(nvcc_version), 4.2),1,)
-
+sm_support = $(shell nvcc -h | grep --only-matching "sm_[0-9][0-9]" | sort --unique)
 
 #
 # default CUDA library path is /usr/local/cuda

--- a/PFAC/src/Makefile
+++ b/PFAC/src/Makefile
@@ -36,49 +36,28 @@ CPP_SRC += PFAC.cpp
 
 inc_files = $(INC_DIR)/PFAC_P.h  $(INC_DIR)/PFAC.h
 
-CU_OBJ = $(patsubst %.cu,%.o,$(CU_SRC))
+CU_CPP = $(patsubst %.cu,%.cu.cpp,$(CU_SRC)) 
 
-CU_CPP = $(patsubst %.cu,%.cu.cpp,$(CU_SRC))
+CPP_OBJ = $(patsubst %.cpp,%.o,$(CPP_SRC)) 
 
-CPP_OBJ = $(patsubst %.cpp,%.o,$(CPP_SRC))
+cu_cpp_obj_loc = $(patsubst %.cpp,$(OBJ_DIR)/$(sm)_%.cpp.o,$(CU_CPP))
 
 cppobj_loc = $(patsubst %.o,$(OBJ_DIR)/%.o,$(CPP_OBJ))
 
 cppobj_fpic_loc = $(patsubst %.o,$(OBJ_DIR)/%_fpic.o,$(CPP_OBJ))
 
+all:  mk_libso_sm mk_lib_fpic
 
-cu_cpp_sm20_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm20_%.cpp,$(CU_CPP))
-cu_cpp_sm13_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm13_%.cpp,$(CU_CPP))
-cu_cpp_sm12_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm12_%.cpp,$(CU_CPP))
-cu_cpp_sm11_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm11_%.cpp,$(CU_CPP))
+mk_libso_sm:
+	$(foreach sm, $(sm_support), $(info Compiling to $(sm)) $(cu_cpp) $(cu_cpp_link))
 
-cu_cpp_obj_sm30_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm30_%.cpp.o,$(CU_CPP))
-cu_cpp_obj_sm21_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm21_%.cpp.o,$(CU_CPP))
-cu_cpp_obj_sm20_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm20_%.cpp.o,$(CU_CPP))
-cu_cpp_obj_sm13_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm13_%.cpp.o,$(CU_CPP))
-cu_cpp_obj_sm12_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm12_%.cpp.o,$(CU_CPP))
-cu_cpp_obj_sm11_loc = $(patsubst %.cpp,$(OBJ_DIR)/sm11_%.cpp.o,$(CU_CPP))
+cu_cpp = $(foreach file, $(CU_SRC), $(cu_cpp_file))
 
-all: mk_libso_no21 mk_libso_21 mk_libso_30  mk_lib_fpic 
+cu_cpp_file = $(shell $(NVCC) -arch=sm_30 -cuda $(INCPATH) -o $(OBJ_DIR)/$(sm)_$(file).cpp $(file) && \
+		$(CXX) -fPIC -O2 -c -o $(OBJ_DIR)/$(sm)_$(file).cpp.o $(OBJ_DIR)/$(sm)_$(file).cpp \
+)
 
-sm30_command := $(if $(sm_30_support),$(CXX) -shared -o $(LIB_DIR)/libpfac_sm30.so $(LIBS) $(cu_cpp_obj_sm30_loc),)
-sm21_command := $(if $(sm_21_support),$(CXX) -shared -o $(LIB_DIR)/libpfac_sm21.so $(LIBS) $(cu_cpp_obj_sm21_loc),)
-
-cu_cpp_sm30_loc := $(if $(sm_30_support),$(patsubst %.cpp,$(OBJ_DIR)/sm30_%.cpp,$(CU_CPP)),)
-cu_cpp_sm21_loc := $(if $(sm_21_support),$(patsubst %.cpp,$(OBJ_DIR)/sm21_%.cpp,$(CU_CPP)),)
-
-
-mk_libso_no21: $(cu_cpp_sm20_loc) $(cu_cpp_sm13_loc) $(cu_cpp_sm12_loc) $(cu_cpp_sm11_loc)
-	$(CXX) -shared -o $(LIB_DIR)/libpfac_sm20.so $(LIBS) $(cu_cpp_obj_sm20_loc)
-	$(CXX) -shared -o $(LIB_DIR)/libpfac_sm13.so $(LIBS) $(cu_cpp_obj_sm13_loc)
-	$(CXX) -shared -o $(LIB_DIR)/libpfac_sm12.so $(LIBS) $(cu_cpp_obj_sm12_loc)
-	$(CXX) -shared -o $(LIB_DIR)/libpfac_sm11.so $(LIBS) $(cu_cpp_obj_sm11_loc)
-
-mk_libso_30: $(cu_cpp_sm30_loc)
-	$(sm30_command)  
-
-mk_libso_21: $(cu_cpp_sm21_loc)
-	$(sm21_command)  
+cu_cpp_link = $(shell $(CXX) -shared -o $(LIB_DIR)/libpfac_$(sm).so $(LIBS) $(cu_cpp_obj_loc))
 
 mk_liba: $(cppobj_loc)
 	ar cru $(LIB_DIR)/libpfac.a  $(cppobj_loc)
@@ -99,37 +78,6 @@ $(OBJ_DIR)/PFAC_CPU_OMP_reorder.o: PFAC_CPU_OMP_reorder.cpp  $(inc_files)
 
 $(OBJ_DIR)/%.o: %.cpp  $(inc_files)
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o $@ $<
-
-
-$(OBJ_DIR)/sm30_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_30 -cuda $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-$(OBJ_DIR)/sm21_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_21 -cuda $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-$(OBJ_DIR)/sm20_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_20 -cuda $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-$(OBJ_DIR)/sm13_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_13 -cuda  $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-$(OBJ_DIR)/sm12_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_12 -cuda  $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-$(OBJ_DIR)/sm11_%.cu.cpp: %.cu
-	$(NVCC) -arch=sm_11 -cuda  $(INCPATH) -o $@ $<
-	$(CXX) -fPIC -O2 -c -o $@.o $@
-
-#clean :
-#	rm -f *.linkinfo
-#	rm -f $(OBJ_DIR)/*
-#	rm -f $(EXE_DIR)/*
-
 
 ####### Implicit rules
 

--- a/PFAC/src/PFAC.cpp
+++ b/PFAC/src/PFAC.cpp
@@ -156,21 +156,11 @@ PFAC_status_t  PFAC_create( PFAC_handle_t *handle )
     PFAC_PRINTF("major = %d, minor = %d, name=%s\n", deviceProp.major, deviceProp.minor, deviceProp.name );
 
     int device_no = 10*deviceProp.major + deviceProp.minor ;
-    if ( 30 == device_no ){
-        strcpy (modulepath, "libpfac_sm30.so");    
-    }else if ( 21 == device_no ){
-        strcpy (modulepath, "libpfac_sm21.so");    
-    }else if ( 20 == device_no ){
-        strcpy (modulepath, "libpfac_sm20.so");
-    }else if ( 13 == device_no ){
-        strcpy (modulepath, "libpfac_sm13.so");
-    }else if ( 12 == device_no ){
-        strcpy (modulepath, "libpfac_sm12.so");
-    }else if ( 11 == device_no ){
-        strcpy (modulepath, "libpfac_sm11.so");
-    }else{
-        return PFAC_STATUS_ARCH_MISMATCH ;
-    }
+    strcpy (modulepath, "libpfac_sm_");
+    char stringnumber[5];
+    sprintf(stringnumber, "%d", device_no);
+    strcat (modulepath, stringnumber);
+    strcat (modulepath, ".so");
     
     (*handle)->device_no = device_no ;
     

--- a/PFAC/src/PFAC_kernel.cu
+++ b/PFAC/src/PFAC_kernel.cu
@@ -120,7 +120,7 @@ __host__  PFAC_status_t  PFAC_kernel_timeDriven_warpper(
         } 
 
         textureReference *texRefTable ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefTable, "tex_PFAC_table" );
+        cuda_status = cudaGetTextureReference( (const struct textureReference**)&texRefTable, &tex_PFAC_table );
         cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<int>();
         // set texture parameters
         tex_PFAC_table.addressMode[0] = cudaAddressModeClamp;

--- a/PFAC/src/PFAC_kernel_spaceDriven.cu
+++ b/PFAC/src/PFAC_kernel_spaceDriven.cu
@@ -184,7 +184,7 @@ __host__  PFAC_status_t  PFAC_kernel_spaceDriven_warpper(
 
         // (1) bind texture to tex_tableOfInitialState
         textureReference *texRefTableOfInitialState ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefTableOfInitialState, "tex_tableOfInitialState" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefTableOfInitialState, &tex_tableOfInitialState );
         cudaChannelFormatDesc channelDesc_tableOfInitialState = cudaCreateChannelDesc<int>();
         // set texture parameters
         tex_tableOfInitialState.addressMode[0] = cudaAddressModeClamp;
@@ -198,7 +198,7 @@ __host__  PFAC_status_t  PFAC_kernel_spaceDriven_warpper(
        
         // (2) bind texture to tex_hashRowPtr
         textureReference *texRefHashRowPtr ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefHashRowPtr, "tex_hashRowPtr" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefHashRowPtr, &tex_hashRowPtr );
         cudaChannelFormatDesc channelDesc_hashRowPtr = cudaCreateChannelDesc<int2>();
         // set texture parameters
         tex_hashRowPtr.addressMode[0] = cudaAddressModeClamp;
@@ -212,7 +212,7 @@ __host__  PFAC_status_t  PFAC_kernel_spaceDriven_warpper(
           
         // (3) bind texture to tex_hashValPtr
         textureReference *texRefHashValPtr ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefHashValPtr, "tex_hashValPtr" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefHashValPtr, &tex_hashValPtr );
         cudaChannelFormatDesc channelDesc_hashValPtr = cudaCreateChannelDesc<int2>();        
         // set texture parameters
         tex_hashValPtr.addressMode[0] = cudaAddressModeClamp;

--- a/PFAC/src/PFAC_reduce_inplace_kernel.cu
+++ b/PFAC/src/PFAC_reduce_inplace_kernel.cu
@@ -668,7 +668,7 @@ __host__  PFAC_status_t PFAC_reduce_space_driven_stage1(
 
         // (1) bind texture to tex_tableOfInitialState
         textureReference *texRefTableOfInitialState ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefTableOfInitialState, "tex_tableOfInitialState_reduce" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefTableOfInitialState, &tex_tableOfInitialState_reduce );
         cudaChannelFormatDesc channelDesc_tableOfInitialState = cudaCreateChannelDesc<int>();
         // set texture parameters
         tex_tableOfInitialState_reduce.addressMode[0] = cudaAddressModeClamp;
@@ -682,7 +682,7 @@ __host__  PFAC_status_t PFAC_reduce_space_driven_stage1(
 
         // (2) bind texture to tex_hashRowPtr
         textureReference *texRefHashRowPtr ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefHashRowPtr, "tex_hashRowPtr_reduce" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefHashRowPtr, &tex_hashRowPtr_reduce );
         cudaChannelFormatDesc channelDesc_hashRowPtr = cudaCreateChannelDesc<int2>();
         // set texture parameters
         tex_hashRowPtr_reduce.addressMode[0] = cudaAddressModeClamp;
@@ -696,7 +696,7 @@ __host__  PFAC_status_t PFAC_reduce_space_driven_stage1(
     
         // (3) bind texture to tex_hashValPtr
         textureReference *texRefHashValPtr ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefHashValPtr, "tex_hashValPtr_reduce" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefHashValPtr, &tex_hashValPtr_reduce );
         cudaChannelFormatDesc channelDesc_hashValPtr = cudaCreateChannelDesc<int2>();
         // set texture parameters
         tex_hashValPtr_reduce.addressMode[0] = cudaAddressModeClamp;

--- a/PFAC/src/PFAC_reduce_kernel.cu
+++ b/PFAC/src/PFAC_reduce_kernel.cu
@@ -333,7 +333,7 @@ __host__  PFAC_status_t PFAC_reduce_kernel_stage1(
         }
     
         textureReference *texRefTable ;
-        cudaGetTextureReference( (const struct textureReference**)&texRefTable, "tex_PFAC_table_reduce" );
+        cudaGetTextureReference( (const struct textureReference**)&texRefTable, &tex_PFAC_table_reduce );
         cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<int>();
         // set texture parameters
         tex_PFAC_table_reduce.addressMode[0] = cudaAddressModeClamp;


### PR DESCRIPTION
* Makefile now compile the lib to all sm gpu archteture sopported by nvcc installed.
* Texture Memory reference is not possible anymore by string naming variable as the symbol paramater since CUDA 5.0