### PR TITLE
BUG FIX: Compile lib to all gpu architecture supported by nvcc

### DIFF
--- a/PFAC/src/Makefile
+++ b/PFAC/src/Makefile
@@ -53,7 +53,7 @@ mk_libso_sm:
 
 cu_cpp = $(foreach file, $(CU_SRC), $(cu_cpp_file))
 
-cu_cpp_file = $(shell $(NVCC) -arch=sm_30 -cuda $(INCPATH) -o $(OBJ_DIR)/$(sm)_$(file).cpp $(file) && \
+cu_cpp_file = $(shell $(NVCC) -arch=$(sm) -cuda $(INCPATH) -o $(OBJ_DIR)/$(sm)_$(file).cpp $(file) && \
 		$(CXX) -fPIC -O2 -c -o $(OBJ_DIR)/$(sm)_$(file).cpp.o $(OBJ_DIR)/$(sm)_$(file).cpp \
 )
 


### PR DESCRIPTION
A bug fix to compiling lib to all sm. All lib sm was compiled to sm_30. 

Sorry, i saw this bug only now.  